### PR TITLE
Fix `Read` and `Show` instances for `Region`.

### DIFF
--- a/components/taiwan-id/Taiwan/ID/Region.hs
+++ b/components/taiwan-id/Taiwan/ID/Region.hs
@@ -30,7 +30,7 @@ import Taiwan.ID.Letter
 import Taiwan.ID.Utilities
   ( randomFinitary )
 import Text.Read
-  ( Lexeme (Ident, Symbol), Read (readPrec), lexP, parens )
+  ( Lexeme (Ident, Symbol), Read (readPrec), lexP, parens, prec )
 
 import qualified Taiwan.ID.Letter as Letter
 
@@ -115,15 +115,16 @@ newtype Region = Region Letter
   deriving anyclass Finitary
 
 instance Read Region where
-  readPrec = parens $ do
+  readPrec = parens $ prec 10 $ do
     Ident "Region"     <- lexP
     Symbol "."         <- lexP
     Ident "fromLetter" <- lexP
     fromLetter <$> readPrec
 
 instance Show Region where
-  showsPrec _ s =
-    showString "Region.fromLetter " . shows (toLetter s)
+  showsPrec d s =
+    showParen (d > 10) $
+      showString "Region.fromLetter " . shows (toLetter s)
 
 -- | Attempts to construct a 'Region' from its corresponding letter code as a
 -- 'Char'.


### PR DESCRIPTION
This PR revises the `Show` and `Read` instances for `Region` so that nested values of `Region` are serialised and deserialised correctly. 

Before:
```hs
>>> Just (Region.fromLetter A)
Just Region.fromLetter A
```

After:
```hs
>>> Just (Region.fromLetter A)
Just (Region.fromLetter A)
```
