### PR TITLE
Revise legal terminology in package description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This package provides a Haskell implementation of Taiwan's uniform
 identification number format.
 
 This number format is used by both National Identification Cards (國民身分證)
-and Alien Resident Certificates (外僑居留證) issued by the Republic of China
-(ROC) government to individuals, with numbers assigned under each system
-occupying disjoint parts of the same identifier space.
+and Resident Certificates (居留證) issued by the Republic of China (ROC)
+government to individuals, with numbers assigned under each system occupying
+disjoint parts of the same identifier space.
 
 Each identification number consists of a single uppercase letter followed by
 nine decimal digits, with the final digit serving as a checksum calculated

--- a/taiwan-id.cabal
+++ b/taiwan-id.cabal
@@ -18,9 +18,9 @@ description:
   identification number format.
 
   This number format is used by both National Identification Cards (國民身分證)
-  and Alien Resident Certificates (外僑居留證) issued by the Republic of China
-  (ROC) government to individuals, with numbers assigned under each system
-  occupying disjoint parts of the same identifier space.
+  and Resident Certificates (居留證) issued by the Republic of China (ROC)
+  government to individuals, with numbers assigned under each system occupying
+  disjoint parts of the same identifier space.
 
   Each identification number consists of a single uppercase letter followed by
   nine decimal digits, with the final digit serving as a checksum calculated


### PR DESCRIPTION
This PR revises the package description to fix incorrect use of the term "Alien Resident Certificate" (外僑居留證).

The term "Alien Resident Certificate" (外僑居留證) refers specifically to resident certificates issued to "foreign nationals" (外國人). However, it does not cover all types of resident certificate issued by the National Immigration Agency (移民署).

The full range of resident certificates issued under the 統一證號 system includes:

  - 外僑居留證 (Alien Resident Certificate)
  - 外僑永久居留證 (Alien Permanent Resident Certificate)
  - 臺灣地區居留證 (Taiwan Area Resident Certificate)
  - 港澳居民居留證 (Hong Kong and Macau Resident Certificate)

The correct umbrella term covering all of these is simply "Resident Certificate" (居留證).