### PR TITLE
Remove empty args when generating CLI commands.

### DIFF
--- a/components/test/taiwan-id-cli-test/Main.hs
+++ b/components/test/taiwan-id-cli-test/Main.hs
@@ -309,7 +309,7 @@ parsePrompt = fmap Text.words . Text.stripPrefix promptPrefix
 -- | Render a list of arguments as a prompt line of the form:
 -- @$ taiwan-id <args...>@
 renderPrompt :: [Text] -> Text
-renderPrompt args = promptPrefix <> Text.intercalate " " args
+renderPrompt args = promptPrefix <> Text.unwords args
 
 --------------------------------------------------------------------------------
 -- CLI execution
@@ -336,16 +336,20 @@ commandInvocationToExpectation CommandInvocation {command, optionStyle} =
     inputCommandLineArgs = renderInvocationArgs optionStyle command
 
 renderInvocationArgs :: OptionStyle -> Command Raw -> [Text]
-renderInvocationArgs style = \case
-  Command.Decode DecodeCommand {idText, language} ->
-    ["decode", runIdentity idText]
-      ++ renderOption style "language" language
-  Command.Generate GenerateCommand {count, seed} ->
-    ["generate"]
-      ++ renderOption style "count" count
-      ++ renderOption style "seed" seed
-  Command.Validate ValidateCommand {idText} ->
-    ["validate", runIdentity idText]
+renderInvocationArgs style =
+  removeEmptyArgs . \case
+    Command.Decode DecodeCommand {idText, language} ->
+      ["decode", runIdentity idText]
+        ++ renderOption style "language" language
+    Command.Generate GenerateCommand {count, seed} ->
+      ["generate"]
+        ++ renderOption style "count" count
+        ++ renderOption style "seed" seed
+    Command.Validate ValidateCommand {idText} ->
+      ["validate", runIdentity idText]
+  where
+    removeEmptyArgs :: [Text] -> [Text]
+    removeEmptyArgs = filter (not . Text.null)
 
 renderOption :: Show a => OptionStyle -> Text -> Maybe a -> [Text]
 renderOption _ _ Nothing = []


### PR DESCRIPTION
Previously, when generating CLI golden files with `--mode=create`, empty arguments (e.g., an empty ID for `validate`) were rendered as trailing spaces. This caused subsequent `--mode=verify` runs to fail, because `System.Environment.getArgs` drops trailing empty arguments, producing different observed output than expected.

This commit wraps `renderInvocationArgs` with a filter that removes empty `Text` values before rendering. This ensures that the golden files exactly match the arguments that the CLI would actually see, eliminating spurious test failures while preserving all non-empty arguments and spacing.