### PR TITLE
Exclude GHC `9.4` on Windows from CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ jobs:
           - '9.8'
           - '9.10'
           - '9.12'
+        exclude:
+          # See https://github.com/jonathanknowles/taiwan-id/issues/47
+          - os: windows-latest
+            ghc: '9.4'
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
This is a temporary workaround for the following issue:

https://github.com/jonathanknowles/taiwan-id/issues/47