### PR TITLE
Include GHC `9.4` on Windows in CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,6 @@ jobs:
           - '9.8'
           - '9.10'
           - '9.12'
-        exclude:
-          # See https://github.com/jonathanknowles/taiwan-id/issues/47
-          - os: windows-latest
-            ghc: '9.4'
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
This reverts 224f882692d647c06c125a5626493adaa3ad0326, which temporarily disabled it.

See: https://github.com/jonathanknowles/taiwan-id/issues/47